### PR TITLE
species image attribution

### DIFF
--- a/_data/species_image_attribution.yml
+++ b/_data/species_image_attribution.yml
@@ -1,0 +1,9 @@
+---
+-
+  gensp: glyma
+  attribution: Bob Smith, Soybean Photographers Intl.
+  year: 2010
+-
+  gensp: glyso
+  attribution: Jane Doe, Soja 'R' Us
+  year: 2015

--- a/_includes/global-stylesheets.html
+++ b/_includes/global-stylesheets.html
@@ -1,1 +1,16 @@
 <!-- place globally-included stylesheet content here -->
+<style>
+  .species-image {
+      float:right;
+      margin:10px;
+  }
+  .species-image img {
+      border:1px solid darkgreen;
+  }
+  .species-image .attribution {
+      text-align: center; 
+      font-style: italic;
+      font-size: 80%;
+  }
+</style>
+

--- a/_layouts/taxon.html
+++ b/_layouts/taxon.html
@@ -65,8 +65,13 @@ taxa_menu: true
 
 {% capture species_photo %}{% file_exists assets/img/species_images/{{ item["abbrev"] }}.jpg %}{% endcapture %}
 {% if species_photo == "true" %}
-<div style="float:right;margin:10px;border:1px solid darkgreen;">
-  <img src="/assets/img/species_images/{{ item["abbrev"] }}.jpg" alt="Image: {{ item["commonName"] }}"/><br/>
+<div class="species-image">
+  <img src="/assets/img/species_images/{{ item["abbrev"] }}.jpg" alt="Image: {{ item["commonName"] }}"/>
+  {% for attribItem in site.data.species_image_attribution %}
+  {%   if attribItem.gensp contains item["abbrev"] %}
+  <div class="attribution">&copy; {{ attribItem.year }} {{ attribItem.attribution }}</div>
+  {%   endif %}
+  {% endfor %}
 </div>
 {% endif %}
 


### PR DESCRIPTION
Place species image attributions in `_data/species_image_attribution.yml` for display under the species images on the taxa pages. A couple of placeholder entries in that file for now. This addresses #22 .