### PR TITLE
Removed apple-touch icon refs. No such file.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -26,15 +26,6 @@
   {% include global-scripts.html %}
 
   <!-- Icons -->
-  <link rel="apple-touch-icon" sizes="57x57" href="{{ "/assets/icons/apple-touch-icon-57x57.png" | relative_url }}">
-  <link rel="apple-touch-icon" sizes="114x114" href="{{ "/assets/icons/apple-touch-icon-114x114.png" | relative_url }}">
-  <link rel="apple-touch-icon" sizes="72x72" href="{{ "/assets/icons/apple-touch-icon-72x72.png" | relative_url }}">
-  <link rel="apple-touch-icon" sizes="144x144" href="{{ "/assets/icons/apple-touch-icon-144x144.png" | relative_url }}">
-  <link rel="apple-touch-icon" sizes="60x60" href="{{ "/assets/icons/apple-touch-icon-60x60.png" | relative_url }}">
-  <link rel="apple-touch-icon" sizes="120x120" href="{{ "/assets/icons/apple-touch-icon-120x120.png" | relative_url }}">
-  <link rel="apple-touch-icon" sizes="76x76" href="{{ "/assets/icons/apple-touch-icon-76x76.png" | relative_url }}">
-  <link rel="apple-touch-icon" sizes="152x152" href="{{ "/assets/icons/apple-touch-icon-152x152.png" | relative_url }}">
-  <link rel="apple-touch-icon" sizes="180x180" href="{{ "/assets/icons/apple-touch-icon-180x180.png" | relative_url }}">
   <link rel="icon" type="image/png" href="{{ "/assets/icons/favicon-192x192.png" | relative_url }}" sizes="192x192">
   <link rel="icon" type="image/png" href="{{ "/assets/icons/favicon-160x160.png" | relative_url }}" sizes="160x160">
   <link rel="icon" type="image/png" href="{{ "/assets/icons/favicon-96x96.png" | relative_url }}" sizes="96x96">

--- a/collections-index.html
+++ b/collections-index.html
@@ -49,15 +49,6 @@
 
 
   <!-- Icons -->
-  <link rel="apple-touch-icon" sizes="57x57" href="/assets/icons/apple-touch-icon-57x57.png">
-  <link rel="apple-touch-icon" sizes="114x114" href="/assets/icons/apple-touch-icon-114x114.png">
-  <link rel="apple-touch-icon" sizes="72x72" href="/assets/icons/apple-touch-icon-72x72.png">
-  <link rel="apple-touch-icon" sizes="144x144" href="/assets/icons/apple-touch-icon-144x144.png">
-  <link rel="apple-touch-icon" sizes="60x60" href="/assets/icons/apple-touch-icon-60x60.png">
-  <link rel="apple-touch-icon" sizes="120x120" href="/assets/icons/apple-touch-icon-120x120.png">
-  <link rel="apple-touch-icon" sizes="76x76" href="/assets/icons/apple-touch-icon-76x76.png">
-  <link rel="apple-touch-icon" sizes="152x152" href="/assets/icons/apple-touch-icon-152x152.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon-180x180.png">
   <link rel="icon" type="image/png" href="/assets/icons/favicon-192x192.png" sizes="192x192">
   <link rel="icon" type="image/png" href="/assets/icons/favicon-160x160.png" sizes="160x160">
   <link rel="icon" type="image/png" href="/assets/icons/favicon-96x96.png" sizes="96x96">


### PR DESCRIPTION
Lack of apple icons (carryover from some previous template) was caught by the html checker. Yanked references.