### PR TITLE
Update tools.yml (dev update this morning)

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -18,7 +18,7 @@
 - category: "Browse and Search"
   description: "Interactive visualization of multiple GWAS and QTL data sets, using synteny to identify potentially conserved association regions between species."
   name: "ZZBrowse GWAS/QTL"
-  url: "https://zzbrowse.lis.ncgr.org/"
+  url: "https://zzbrowse.legumeinfo.org/"
 - category: "Browse and Search"
   description: "View genetic and comparative maps."
   name: "CMap"


### PR DESCRIPTION
Switched to zzbrowse.legumeinfo.org. No other lis.ncgr.org URLs in the list. Just pulling this update into scannon before scannon is merged back, so you're up to date.