### PR TITLE
Deploy to legumeinfo/legumeinfo.org on tag

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,9 +1,11 @@
-name: Build and deploy jekyll-stage.legumeinfo.org
+name: Build and deploy jekyll-stage.legumeinfo.org or www.legumeinfo.org
 
 on:
   push:
     branches:
-      - main
+      - 'main'
+    tags:
+      - '**'
 
 jobs:
   github-pages:
@@ -32,11 +34,23 @@ jobs:
           # --disable-external included for efficiency, eventually remove?
           arguments: "--disable-external --assume-extension"
 
-      - name: Deploy
+      - name: Deploy (stage)
         uses: peaceiris/actions-gh-pages@v3
         # Always deploy for now, despite htmlproofer errors (eventually remove)
-        if: always()
+        if: github.ref_type == 'branch' && always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
           publish_branch: 'jekyll-stage.legumeinfo.org'
+          cname: jekyll-stage.legumeinfo.org
+
+      - name: Deploy (prod)
+        uses: peaceiris/actions-gh-pages@v3
+        # Always deploy for now, despite htmlproofer errors (eventually remove)
+        if: github.ref_type == 'tag' && always()
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          publish_dir: ./_site
+          external_repository: legumeinfo/legumeinfo.org
+          publish_branch: www.legumeinfo.org
+          cname: www.legumeinfo.org

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-jekyll-stage.legumeinfo.org

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # legumeinfo.org
-This repository holds the [Jekyll](https://jekyllrb.com/) site hosted at legumeinfo.org.
+This repository holds the [Jekyll](https://jekyllrb.com/) site hosted at www.legumeinfo.org.
+
+Commits to the `main` branch will trigger a GitHub Action workflow that build the static site & deploy to the jekyll-stage.legumeinfo.org branch.
+This branch is hosted via GitHub Pages at https://jekyll-stage.legumeinfo.org.
+
+When a tag is pushed, a GitHub Action workflow will build the static site & deploy to the [legumeinfo/legumeinfo.org](https://github.com/legumeinfo/legumeinfo.org) repository (www.legumeinfo.org branch).
+This branch is hosted via GitHub Pages at https://www.legumeinfo.org (requests for https://legumeinfo.org will redirect to https://www.legumeinfo.org).
 
 ## Running the Site
 The following methods will run the site on your computer at http://localhost:4000.


### PR DESCRIPTION
Modify GA workflow to deploy to legumeinfo/legumeinfo.org@www.legumeinfo.org on tag.

 [GitHub Pages requires an apex domain to redirect to www subdomain or vice-versa](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain) (which is also apparently typical practice outside of GitHub Pages); this PR proposes redirecting legumeinfo.org -> www.legumeinfo.org