### PR TITLE
Jointvetch genome/annotation READMEs added

### DIFF
--- a/_data/taxa/Aeschynomene/species_collections.yml
+++ b/_data/taxa/Aeschynomene/species_collections.yml
@@ -2,8 +2,12 @@
 species:
 - name: evenia
   annotations:
+    - collection: CIAT22838.gnm1.ann1.ZM3R
+      synopsis: "Aeschynomene evenia isolate CIAT22838, whole genome shotgun sequencing project."
   diversity:
   expression:
   genetic:
   genomes:
+    - collection: CIAT22838.gnm1.XF73
+      synopsis: "Aeschynomene evenia isolate CIAT22838, whole genome shotgun sequencing project."
   markers:

--- a/_includes/navbar-menu-items.html
+++ b/_includes/navbar-menu-items.html
@@ -34,6 +34,14 @@
         {% endif %}
         {% endfor %}
         {% endfor %}
+        <li class="uk-nav-divider"></li>
+        {% for genus in genera %}
+        {% for item in genus.items %}
+        {% if item.category == "special" %}
+        <li><a href="/collections{{ item.genus | downcase | relative_url }}"> {{ item.genus }} ({{ item.description }})</a></li>
+        {% endif %}
+        {% endfor %}
+        {% endfor %}
       </ul>
     </div>
   </li>


### PR DESCRIPTION
I've added READMEs for the jointvetch genome assembly/annotation, not having noticed that they were missing since I haven't built JointvetchMine in ages. This puts the collection URLs onto the website on /collections/aeschynomene/

(PRing to dev for a big test of the htmlchecker update.)