### PR TITLE
Clone datastore-metadata locally and load YAML from that.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site
 .DS_Store
 vendor
 *~
+_scripts/datastore-metadata/

--- a/_data/taxa/Aeschynomene/species_collections.yml
+++ b/_data/taxa/Aeschynomene/species_collections.yml
@@ -4,10 +4,6 @@ species:
   annotations:
     - collection: CIAT22838.gnm1.ann1.ZM3R
       synopsis: "Aeschynomene evenia isolate CIAT22838, whole genome shotgun sequencing project."
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: CIAT22838.gnm1.XF73
       synopsis: "Aeschynomene evenia isolate CIAT22838, whole genome shotgun sequencing project."
-  markers:

--- a/_data/taxa/Apios/species_collections.yml
+++ b/_data/taxa/Apios/species_collections.yml
@@ -1,11 +1,6 @@
 ---
 species:
 - name: americana
-  annotations:
   diversity:
     - collection: LA2155.tcp.div.Singh_Kalberer_2018
       synopsis: "SNP calls on a collection of accessions, relative to a reference sequence (derived from a transcriptome assembly of Apios americana)"
-  expression:
-  genetic:
-  genomes:
-  markers:

--- a/_data/taxa/Arachis/genus_resources.yml
+++ b/_data/taxa/Arachis/genus_resources.yml
@@ -19,7 +19,7 @@ resources:
 - URL: https://peanutbase.org/germplasm/gcvit
   description: 'Genetic variation viewer '
   name: GCViT
-- URL: https://gcv.legumeinfo.org/gene;lis=arahy.P7Z3M8?q=arahy.CMRI1Q&sources=lis&algorithm=repeat&match=10&mismatch=-1&gap=-1&score=30&threshold=25&bmatched=20&bintermediate=10&bmask=10&linkage=average&cthreshold=20&neighbors=10&matched=4&intermediate=5&bregexp=&border=chromosome&regexp=&order=distance
+- URL: https://gcv.legumeinfo.org/gene;lis=arahy.Tifrunner.gnm1.ann1.P7Z3M8?q=arahy.P7Z3M8
   description: Browser for dynamically discovering and viewing genomic synteny across
     selected species.
   name: Genome Context Viewer

--- a/_data/taxa/Arachis/species_collections.yml
+++ b/_data/taxa/Arachis/species_collections.yml
@@ -13,7 +13,6 @@ species:
       synopsis: "Diversity data for the U.S. peanut core collection, genotyped relative to the diploid A. duranensis and A. ipaensis genome assemblies."
     - collection: aradu1_araip1.gnm1.div.Otyama_Wilkey_2019
       synopsis: "Genotype data for US Peanut Mini Core collection."
-  expression:
   genetic:
     - collection: Huayu28_x_P76.gen.Hu_Zhang_2018
       synopsis: "A genetic map from a Huayu28 x P76 RIL population composed of 2,334 markers (2,266 SNPs and 68 microsatellites) for the study of seed oleic and linoleic acid content"
@@ -21,10 +20,6 @@ species:
       synopsis: "SSR genetic map generated from a RIL mapping population derived from the cross of ICGS 44 and ICGS 76"
     - collection: ICGS76_x_CSMG84.gen.Gautami_Pandey_2012
       synopsis: "SSR genetic map generated from a RIL population derived from the cross of ICGS 76 with CSMG 84-1"
-    - collection: mixed.gen.Gautami_Pandey_2012
-      synopsis: "Consensus genetic map for Arachis hypogaea from three RIL populations: ICGS76 x CSMG84-1, ICGS44 x ICGS76, and TAG24 x ICGV86031"
-    - collection: mixed.gen.Sujay_Gowda_2012
-      synopsis: "A consensus genetic map for Arachis hypogaea built from TAG24 x GPBD4 and TG26 x GPBD4 RIL populations"
     - collection: NAMFlor7.gwas.Gangurde_Wang_2020
       synopsis: "Gangurde, Wang, et al. (2020) GWAS study of pod and seed weight on the NAM Florida-7 mapping population"
     - collection: NAMTifr.gwas.Gangurde_Wang_2020
@@ -49,6 +44,10 @@ species:
       synopsis: "GWAS determining markers associated with fatty acid composition in the USDA peanut core collection."
     - collection: VG9514_x_TAG24.gen.Mondal_Hadapad_2014
       synopsis: "Genetic map derived from a cross of A. hypogaea cultivars VG 9514 and TAG 24."
+    - collection: mixed.gen.Gautami_Pandey_2012
+      synopsis: "Consensus genetic map for Arachis hypogaea from three RIL populations: ICGS76 x CSMG84-1, ICGS44 x ICGS76, and TAG24 x ICGV86031"
+    - collection: mixed.gen.Sujay_Gowda_2012
+      synopsis: "A consensus genetic map for Arachis hypogaea built from TAG24 x GPBD4 and TG26 x GPBD4 RIL populations"
   genomes:
     - collection: Fuhuasheng.gnm1.XX5Y
       synopsis: "Genome assembly for tetraploid peanut cultivar Fuhuasheng, from Chen et al., 2019"
@@ -59,12 +58,16 @@ species:
     - collection: Tifrunner.gnm2.J5K5
       synopsis: "Genome assembly 2 for Arachis hypogaea, cultivar Tifrunner. This version has structural changes relative to assembly 1."
   markers:
+    - collection: Tifrunner.gnm1.mrk.Agarwal_Clevenger_2018
+      synopsis: "Genetic map of Tifrunner x GT-C20 for the study of early and late leaf spots (ELS and LLS) and tomato spotted wilt virus (TSWV)."
+    - collection: Tifrunner.gnm1.mrk.Axiom_Arachis2
+      synopsis: "Axiom_Arachis2 is a SNP marker set developed by Clevenger, et al. DOI:10.1016/j.molp.2016.11.015"
+    - collection: Tifrunner.gnm1.mrk.Axiom_Arachis_58K
+      synopsis: "Axiom_Arachis_58K is a high-density SNP array with 58,233 SNPs reduced from 163,782 SNPs derived from DNA resequencing and RNA-sequencing of 41 groundnut accessions and wild diploid ancestors."
 - name: duranensis
   annotations:
     - collection: V14167.gnm1.ann1.cxSM
       synopsis: "genome annotations"
-  diversity:
-  expression:
   genetic:
     - collection: PI475887_x_Grif15036.gen.Nagy_Guo_2012
       synopsis: "AA_A.duranensis_x_A.duranensis_a, SNP and SSR-based genetic map of Arachis duranensis from a cross of 'PI 475887' and 'Grif 15036'."
@@ -73,26 +76,16 @@ species:
       synopsis: "Genome assembly 1 for Arachis duranensis, accession V14167"
     - collection: V14167.gnm2.J7QH
       synopsis: "Genome assembly 2 for Arachis duranensis, accession V14167"
-  markers:
 - name: ipaensis
   annotations:
     - collection: K30076.gnm1.ann1.J37m
       synopsis: "genome annotations for Arachis ipaensis K30076.gnm1.ann1"
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: K30076.gnm1.bXJ8
       synopsis: "Genome assembly 1 for Arachis ipaensis, accession K30076."
     - collection: K30076.gnm2.1GWY
       synopsis: "Genome Assembly 2 for A. ipaensis K30076. A high-quality chromosome-scale assembly, based on PacBio RSII and Sequel reads, ordered into pseudomolecules by Dovetail using Hi-C Chicago libraries and the HiRise and SNAP."
-  markers:
 - name: cardenasii
-  annotations:
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: K10017.gnm1.DQ4M
       synopsis: "Genome assembly 1 for Arachis cardenasii, accession K10017"
-  markers:

--- a/_data/taxa/Arachis/species_resources.yml
+++ b/_data/taxa/Arachis/species_resources.yml
@@ -21,7 +21,7 @@ species:
   - URL: https://peanutbase.org/germplasm/gcvit
     description: 'Genetic variation viewer '
     name: GCViT
-  - URL: https://gcv.legumeinfo.org/gene;lis=arahy.P7Z3M8?q=arahy.CMRI1Q&sources=lis&algorithm=repeat&match=10&mismatch=-1&gap=-1&score=30&threshold=25&bmatched=20&bintermediate=10&bmask=10&linkage=average&cthreshold=20&neighbors=10&matched=4&intermediate=5&bregexp=&border=chromosome&regexp=&order=distance
+  - URL: https://gcv.legumeinfo.org/gene;lis=arahy.Tifrunner.gnm1.ann1.P7Z3M8?q=arahy.P7Z3M8
     description: Browser for dynamically discovering and viewing genomic synteny across
       selected species.
     name: Genome Context Viewer

--- a/_data/taxa/Cajanus/species_collections.yml
+++ b/_data/taxa/Cajanus/species_collections.yml
@@ -6,11 +6,9 @@ species:
       synopsis: "Cajanus cajan accession ICPL87119 genome annotation, v1.0"
     - collection: ICPL87119.gnm2.ann1.L3ZH
       synopsis: "genome annotation of Cajanus cajan (ICPL87119 genoome assembly 2)"
-  diversity:
   expression:
     - collection: ICPL87119.gnm1.ann1.expr.4H6Z
       synopsis: "Cajanus cajan accession ICPL87119 gene expression atlas"
-  genetic:
   genomes:
     - collection: ICPL87119.gnm1.SBGP
       synopsis: "Cajanus cajon accession ICPL87119 genome assembly, v1.0"

--- a/_data/taxa/Cercis/species_collections.yml
+++ b/_data/taxa/Cercis/species_collections.yml
@@ -4,10 +4,6 @@ species:
   annotations:
     - collection: ISC453364.gnm1.ann1.HZJM
       synopsis: "Gene annotations for Cercis canadensis genome assembly 1"
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: ISC453364.gnm1.B05Z
       synopsis: "Draft genome assembly for Cercis canadensis"
-  markers:

--- a/_data/taxa/Chamaecrista/species_collections.yml
+++ b/_data/taxa/Chamaecrista/species_collections.yml
@@ -4,10 +4,6 @@ species:
   annotations:
     - collection: MN87.gnm1.ann1.LWFM
       synopsis: "Draft genome assembly for Chamaecrista fasciculata"
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: MN87.gnm1.JXFN
       synopsis: "Draft genome assembly for Chamaecrista fasciculata"
-  markers:

--- a/_data/taxa/Cicer/species_collections.yml
+++ b/_data/taxa/Cicer/species_collections.yml
@@ -4,8 +4,6 @@ species:
   annotations:
     - collection: CDCFrontier.gnm1.ann1.nRhs
       synopsis: "genome annotation of Cicer arietium (kabuli variety)"
-    - collection: CDCFrontier.gnm2.ann1.9M1L
-      synopsis: "genome annotation of Cicer arietium (kabuli variety)"
     - collection: ICC4958.gnm2.ann1.LCVX
       synopsis: "genome annotation of Cicer arietium (desi variety)"
   diversity:
@@ -14,12 +12,8 @@ species:
   expression:
     - collection: CDCFrontier.gnm1.ann1.expr.C14F
       synopsis: "Gene expression dataset for Cicer arietinum ICC4958 desi variety MAPPED TO CDCFrontier (kabuli variety) genome."
-  genetic:
   genomes:
     - collection: CDCFrontier.gnm1.GkHc
       synopsis: "Genome assembly of Cicer arietinum CDCFrontier (kabuli variety)."
-    - collection: CDCFrontier.gnm2.S2FF
-      synopsis: "Cicer arietinum genotype CDCFrontier genome assembly v2.0"
     - collection: ICC4958.gnm2.bg5m
       synopsis: "Genome assembly of Cicer arietinum ICC4958 (desi variety)."
-  markers:

--- a/_data/taxa/Faidherbia/species_collections.yml
+++ b/_data/taxa/Faidherbia/species_collections.yml
@@ -4,10 +4,6 @@ species:
   annotations:
     - collection: WAFC.gnm1.ann1.RTP9
       synopsis: "Gene models for the Apple-Ring Acacia (Faidherbia albida)"
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: WAFC.gnm1.ZT1R
       synopsis: "Draft genome assembly for the Apple-Ring Acacia (Faidherbia albida)"
-  markers:

--- a/_data/taxa/Glycine/species_collections.yml
+++ b/_data/taxa/Glycine/species_collections.yml
@@ -51,8 +51,6 @@ species:
       synopsis: "Resequencing information for 302 wild and cultivated soybean accessions."
     - collection: Wm82.gnm2.div.Bandillo_Lorenz_2017
       synopsis: "Haplotypes of SoyNAM parents and progeny with respect to Williams 82 gnm2."
-    - collection: Wm82.gnm2.div.dosSantos_Valliyodan_2016
-      synopsis: "VCF and HapMap file containing genotype information for 28 Brazilian soybean accessions."
     - collection: Wm82.gnm2.div.Jeong_Moon_2019
       synopsis: "Variant information for 4234 soybean accessions (Glycine max and Glycine soja) genotyped with the Axiom SoyaSNP array containing 180,961 SNPs."
     - collection: Wm82.gnm2.div.Lam_Xu_2010
@@ -77,6 +75,8 @@ species:
       synopsis: "VCF files containing genotype information for 3 populations of soybean produced by GB-eaSy."
     - collection: Wm82.gnm2.div.Zhang_Jiang_2020
       synopsis: "Variant information for 1,556 resequenced soybean accessions Glycine max and Glycine soja, provided by Yong-Qiang (Charles) An and Rick Meyers, relative to Wm82 assembly 2."
+    - collection: Wm82.gnm2.div.dosSantos_Valliyodan_2016
+      synopsis: "VCF and HapMap file containing genotype information for 28 Brazilian soybean accessions."
   expression:
     - collection: Wm82.gnm1.ann1.expr.Z679
       synopsis: "Cystatin expression during 3 root nodule development stages : vegetative, reproductive and senescence (Van Wyk et. al. 2014)."
@@ -117,28 +117,38 @@ species:
       synopsis: "QTL analysis of root traits as related to phosphorus efficiency in soybean"
     - collection: BD2_x_BX10.gen.Liang_Cheng_2010b
       synopsis: "QTL analysis of root traits as related to phosphorus efficiency in soybean"
+    - collection: BSR101_x_LG82-8379.gen.Kabelka_Diers_2004
+      synopsis: "Putative Alleles for Increased Yield from Soybean Plant Introductions"
+    - collection: BSR101_x_PI437654.gen.Klos_Paz_2000
+      synopsis: "Molecular Markers Useful for Detecting Resistance to Brown Stem Rot in Soybean"
     - collection: Bell_x_Colfax.gen.Glover_Wang_2004
       synopsis: "Near Isogenic Lines Confirm a Soybean Cyst Nematode Resistance Gene from PI 88788 on Linkage Group J"
     - collection: Bell_x_Colfax.gen.Patzoldt_Grau_2005
       synopsis: "Localization of a Quantitative Trait Locus Providing Brown Stem Rot Resistance in the Soybean Cultivar Bell"
-    - collection: Benning_x_PI416937.gen.Abdel-Haleem_Carter_2012
-      synopsis: "Mapping of quantitative trait loci for canopy-wilting trait in soybean (Glycine max L. Merr)"
     - collection: BenningPI595645_x_DanbaekkongPI619083.gen.Warrington_Abdel-Haleem_2015
       synopsis: "QTL for seed protein and amino acids in the Benning × Danbaekkong soybean population"
     - collection: BenningPI595645_x_PI416937.gen.Abdel-Haleem_Lee_2011
       synopsis: "Identification of QTL for increased fibrous roots in soybean"
     - collection: BenningPI595645_x_PI416937.gen.Carpentieri-Pipolo_Pipolo_2012
       synopsis: "Identification of QTLs associated with limited leaf hydraulic conductance in soybean"
+    - collection: Benning_x_PI416937.gen.Abdel-Haleem_Carter_2012
+      synopsis: "Mapping of quantitative trait loci for canopy-wilting trait in soybean (Glycine max L. Merr)"
     - collection: Birsasoya-1_x_JS71-05.gen.Singh_Raipuria_2008
       synopsis: "SSR markers associated with seed longevity in soybean"
     - collection: Bogao_x_Nannong94-156.gen.Jun_Freewalt_2014
       synopsis: "Identification of novel QTL for leaf traits in soybean"
     - collection: Bossier_x_Embrapa20.gen.Santos_Geraldi_2013
       synopsis: "Mapping of QTLs associated with biological nitrogen fixation traits in soybean"
-    - collection: BSR101_x_LG82-8379.gen.Kabelka_Diers_2004
-      synopsis: "Putative Alleles for Increased Yield from Soybean Plant Introductions"
-    - collection: BSR101_x_PI437654.gen.Klos_Paz_2000
-      synopsis: "Molecular Markers Useful for Detecting Resistance to Brown Stem Rot in Soybean"
+    - collection: CNS_x_PI230977.gen.Tamulonis_Luzzi_1997a
+      synopsis: "RFLP Mapping of Resistance to Southern Root‐Knot Nematode in Soybean"
+    - collection: CNS_x_PI230977.gen.Tamulonis_Luzzi_1997b
+      synopsis: "DNA Markers Associated with Resistance to Javanese Root‐Knot Nematode in Soybean"
+    - collection: CSSL3228_x_NN1138D2.gen.Zhang_Wang_2018
+      synopsis: "Combining QTL-seq and linkage mapping to fine map a wild soybean allele characteristic of greater plant height"
+    - collection: CX1834-1-2_x_5601T.gen.Scaboo_Pantalone_2009
+      synopsis: "Confirmation of Molecular Markers and Agronomic Traits Associated with Seed Phytate Content in Two Soybean RIL Populations"
+    - collection: CX1834-1-6_x_V99-3337.gen.Gao_Biyashev_2008
+      synopsis: "Validation of Low-Phytate QTLs and Evaluation of Seedling Emergence of Low-Phytate Soybeans"
     - collection: Chamame_x_Laco-1.gen.Juwattanasomran_Somta_2012
       synopsis: "Identification of a new fragrance allele in soybean and development of its functional marker"
     - collection: Charleston_x_Dongnong.gen.Qi_Wu_2011
@@ -147,10 +157,6 @@ species:
       synopsis: "Quantitative trait loci analysis for the developmental behavior of Soybean (Glycine max L. Merr.)"
     - collection: Charleston_x_Dongnong594.gen.Sun_Pan_2012
       synopsis: "Multi-environment mapping and meta-analysis of 100-seed weight in soybean"
-    - collection: CNS_x_PI230977.gen.Tamulonis_Luzzi_1997a
-      synopsis: "RFLP Mapping of Resistance to Southern Root‐Knot Nematode in Soybean"
-    - collection: CNS_x_PI230977.gen.Tamulonis_Luzzi_1997b
-      synopsis: "DNA Markers Associated with Resistance to Javanese Root‐Knot Nematode in Soybean"
     - collection: Cobb_x_PI171451.gen.Rector_All_1999
       synopsis: "Quantitative Trait Loci for Antixenosis Resistance to Corn Earworm in Soybean"
     - collection: Cobb_x_PI229358.gen.Narvel_Walker_2001
@@ -179,12 +185,6 @@ species:
       synopsis: "Dissection of two soybean QTL conferring partial resistance to Phytophthora sojae through sequence and gene expression analysis"
     - collection: Cook_x_N87-2122-4.gen.Li_Wilson_2002
       synopsis: "Molecular Mapping Genes Conditioning Reduced Palmitic Acid Content in N87-2122-4 Soybean"
-    - collection: CSSL3228_x_NN1138D2.gen.Zhang_Wang_2018
-      synopsis: "Combining QTL-seq and linkage mapping to fine map a wild soybean allele characteristic of greater plant height"
-    - collection: CX1834-1-2_x_5601T.gen.Scaboo_Pantalone_2009
-      synopsis: "Confirmation of Molecular Markers and Agronomic Traits Associated with Seed Phytate Content in Two Soybean RIL Populations"
-    - collection: CX1834-1-6_x_V99-3337.gen.Gao_Biyashev_2008
-      synopsis: "Validation of Low-Phytate QTLs and Evaluation of Seedling Emergence of Low-Phytate Soybeans"
     - collection: DongNong1068_x_DongNong8004.gen.Zhao_Wang_2008
       synopsis: "Identification of QTL underlying the resistance of soybean to pod borer, Leguminivora glycinivorella (Mats.) obraztsov, and correlations with plant, pod and seed traits"
     - collection: DongNong46_x_KenJian23.gen.Mao_Jiang_2013
@@ -229,10 +229,10 @@ species:
       synopsis: "Molecular mapping and identification of soybean fatty acid modifier quantitative trait loci"
     - collection: Essex_x_Williams.gen.Hyten_Pantalone_2004b
       synopsis: "Seed quality QTL in a prominent soybean population"
-    - collection: Evans_x_Peking.gen.Concibido_Lange_1997
-      synopsis: "Genome Mapping of Soybean Cyst Nematode Resistance Genes in ‘Peking’, PI 90763, and PI 88788 Using DNA Markers"
     - collection: Evans_x_PI88788.gen.Concibido_Young_1996
       synopsis: "Targeted comparative genome analysis and qualitative mapping of a major partial-resistance gene to the soybean cyst nematode"
+    - collection: Evans_x_Peking.gen.Concibido_Lange_1997
+      synopsis: "Genome Mapping of Soybean Cyst Nematode Resistance Genes in ‘Peking’, PI 90763, and PI 88788 Using DNA Markers"
     - collection: FiskbeyIII_x_Williams82.gen.Do_Vuong_2018
       synopsis: "Mapping and confirmation of loci for salt tolerance in a novel soybean germplasm, Fiskeby III"
     - collection: FiskebyIII_x_Mandarin.gen.Burton_Burkey_2016
@@ -259,10 +259,10 @@ species:
       synopsis: "QTLs for resistance to soybean cyst nematode, races 3, 9, and 14 in cultivar Hartwig"
     - collection: Hayahikari_x_Toyomusume.gen.Funatsuki_Ishimoto_2006
       synopsis: "Simple sequence repeat markers linked to a major QTL controlling pod shattering in soybean"
-    - collection: Hefeng25_x_Conrad.gen.Han_Li_2012
-      synopsis: "QTL analysis of soybean seed weight across multi-genetic backgrounds and environments"
     - collection: HeFeng25_x_DongnongL-5.gen.Xie_Han_2012
       synopsis: "SSR- and SNP-related QTL underlying linolenic acid and other fatty acid contents in soybean seeds across multiple environments"
+    - collection: Hefeng25_x_Conrad.gen.Han_Li_2012
+      synopsis: "QTL analysis of soybean seed weight across multi-genetic backgrounds and environments"
     - collection: Hefeng25_x_MapleArrow.gen.Li_Sun_2010
       synopsis: "Identification of QTL underlying soluble pigment content in soybean stems related to resistance to soybean white mold (Sclerotinia sclerotiorum)"
     - collection: Hefeng25_x_OACBayfield.gen.Li_Wang_2016
@@ -279,6 +279,12 @@ species:
       synopsis: "Identification of putative QTL that underlie yield in interspecific soybean backcross populations"
     - collection: Ippon-Sangoh_x_Fukuyutaka.gen.Komatsu_Hwang_2012
       synopsis: "Identification of QTL controlling post-flowering period in soybean"
+    - collection: JP036034_x_Ryuhou.gen.Wang_Chen_2015
+      synopsis: "Identification of Quantitative Trait Loci for Oil Content in Soybean Seed"
+    - collection: JP110755_x_Fukuyutaka.gen.Kuroda_Kaga_2013
+      synopsis: "QTL affecting fitness of hybrids between wild and cultivated soybeans in experimental fields"
+    - collection: JWS156-1_x_Jackson.gen.Tuyen_Lal_2010
+      synopsis: "Identification of a major QTL allele from wild soybean (Glycine soja Sieb. & Zucc.) for increasing alkaline salt tolerance in soybean"
     - collection: Jackson_x_JWS156-1.gen.Hamwieh_Xu_2008
       synopsis: "Conserved salt tolerance quantitative trait locus (QTL) in wild and cultivated soybeans"
     - collection: Jidou12_x_JiNF58.gen.Shi_Yan_2018
@@ -293,12 +299,14 @@ species:
       synopsis: "QTL identification of yield-related traits and their association with flowering and maturity in soybean"
     - collection: Jinpumkong_x_SS2-2.gen.Liu_Kim_2011
       synopsis: "QTL identification of flowering time at three different latitudes reveals homeologous genomic regions that control flowering in soybean"
-    - collection: JP036034_x_Ryuhou.gen.Wang_Chen_2015
-      synopsis: "Identification of Quantitative Trait Loci for Oil Content in Soybean Seed"
-    - collection: JP110755_x_Fukuyutaka.gen.Kuroda_Kaga_2013
-      synopsis: "QTL affecting fitness of hybrids between wild and cultivated soybeans in experimental fields"
-    - collection: JWS156-1_x_Jackson.gen.Tuyen_Lal_2010
-      synopsis: "Identification of a major QTL allele from wild soybean (Glycine soja Sieb. & Zucc.) for increasing alkaline salt tolerance in soybean"
+    - collection: KF1_x_NN1138-2.gen.Li_Zhao_2011
+      synopsis: "Genetic structure composed of additive QTL, epistatic QTL pairs and collective unmapped minor QTL conferring oil content and fatty acid components of soybeans"
+    - collection: KFNo1_x_NN1138-2.gen.Korir_Qi_2011
+      synopsis: "A study on relative importance of additive, epistasis and unmapped QTL for Aluminium tolerance at seedling stage in soybean"
+    - collection: KS4303sp_x_PI407818B.gen.Orazaly_Chen_2015
+      synopsis: "Identification and Confirmation of Quantitative Trait Loci Associated with Soybean Seed Hardness"
+    - collection: KS4895_x_Jackson.gen.Charlson_Bhatnagar_2009
+      synopsis: "Polygenic inheritance of canopy wilting in soybean [Glycine max (L.) Merr.]"
     - collection: Kaori_x_ChiangMai60.gen.Juwattanasomran_Somta_2011
       synopsis: "A SNP in GmBADH2 gene associates with fragrance in vegetable soybean variety “Kaori” and SNAP marker development for the fragrance"
     - collection: Karafuto-1_x_Toyosuzu.gen.Khan_Githiri_2008
@@ -341,23 +349,15 @@ species:
       synopsis: "Mapping QTLs with epistatic effects and QTL-by-environment interactions for seed coat cracking in soybeans"
     - collection: Keunolkong_x_Sinpaldalkong.gen.Kang_Kwak_2009
       synopsis: "Population-specific QTLs and their different epistatic interactions for pod dehiscence in soybean [Glycine max (L.) Merr.]"
-    - collection: KF1_x_NN1138-2.gen.Li_Zhao_2011
-      synopsis: "Genetic structure composed of additive QTL, epistatic QTL pairs and collective unmapped minor QTL conferring oil content and fatty acid components of soybeans"
-    - collection: KFNo1_x_NN1138-2.gen.Korir_Qi_2011
-      synopsis: "A study on relative importance of additive, epistasis and unmapped QTL for Aluminium tolerance at seedling stage in soybean"
     - collection: Kitakomachi_x_Koganejiro.gen.Githiri_Yang_2007
       synopsis: "QTL Analysis of Low Temperature Induced Browning in Soybean Seed Coats"
     - collection: Kottman_x_PI391589B.gen.Guo_Wang_2008
       synopsis: "Genetic Mapping of QTLs Underlying Partial Resistance to in Soybean PI 391589A and PI 391589B"
-    - collection: KS4303sp_x_PI407818B.gen.Orazaly_Chen_2015
-      synopsis: "Identification and Confirmation of Quantitative Trait Loci Associated with Soybean Seed Hardness"
-    - collection: KS4895_x_Jackson.gen.Charlson_Bhatnagar_2009
-      synopsis: "Polygenic inheritance of canopy wilting in soybean [Glycine max (L.) Merr.]"
     - collection: L-10_x_Heinong37.gen.Chang_Dong_2011
       synopsis: "QTL underlying resistance to two HG types of Heterodera glycines found in soybean cultivar 'L-10'"
     - collection: L78-4094_x_Century84.gen.Bachman_Tamulonis_2001
       synopsis: "Molecular Markers Linked to Brown Stem Rot Resistance Genes,Rbs1andRbs2, in Soybean"
-    - collection: LD00-2817P_x_LDX01-1-65.gen.Vald%C3%A9s-L%C3%B3pez_Thibivilliers_2011
+    - collection: LD00-2817P_x_LDX01-1-65.gen.Valdés-López_Thibivilliers_2011
       synopsis: "Identification of Quantitative Trait Loci Controlling Gene Expression during the Innate Immunity Response of Soybean    "
     - collection: Lineage69_x_Tucunare.gen.Leite_Pinheiro_2016
       synopsis: "QTL mapping of soybean oil content for marker-assisted selection in plant breeding program"
@@ -369,7 +369,15 @@ species:
       synopsis: "Mapping QTL for Seed Protein and Oil Content in Eight Soybean Populations"
     - collection: M91-212006_x_SZG9652.gen.Vollmann_Schausberger_2002
       synopsis: "The presence or absence of the soybean Kunitz trypsin inhibitor as a quantitative trait locus for seed protein content"
-    - collection: MaBelle_x_Proto.gen.Csan%C3%A1di_Vollmann_2001
+    - collection: MD96-5722_x_Spencer.gen.Akond_Liu_2014
+      synopsis: "Identification of Quantitative Trait Loci (QTL) Underlying Protein, Oil, and Five Major Fatty Acids’ Contents in Soybean"
+    - collection: MD96-5722_x_Spencer.gen.Anderson_Akond_2015
+      synopsis: "Quantitative trait loci underlying resistance to sudden death syndrome (SDS) in MD96-5722 by ‘Spencer’ recombinant inbred line population of soybean"
+    - collection: MFS-553_x_PI243545.gen.Zeng_Chen_2014
+      synopsis: "Identification of Quantitative Trait Loci for Sucrose Content in Soybean Seed"
+    - collection: MN1606SP_x_Spencer.gen.Luckew_Swaminathan_2017
+      synopsis: "‘MN1606SP’ by ‘Spencer’ filial soybean population reveals novel quantitative trait loci and interactions among loci conditioning SDS resistance"
+    - collection: MaBelle_x_Proto.gen.Csanádi_Vollmann_2001
       synopsis: "Seed quality QTLs identified in a molecular map of early maturing soybean"
     - collection: Magellan_x_PI404198A.gen.Guo_Sleper_2006
       synopsis: "Quantitative Trait Loci underlying Resistance to Three Soybean Cyst Nematode Populations in Soybean PI 404198A"
@@ -381,14 +389,8 @@ species:
       synopsis: "Novel quantitative trait loci for broad-based resistance to soybean cyst nematode (Heterodera glycines Ichinohe) in soybean PI 567516C"
     - collection: MapleDonovan_x_OACBayfield.gen.Huynh_Bastien_2010
       synopsis: "Identification of QTLs Associated with Partial Resistance to White Mold in Soybean Using Field-Based Inoculation"
-    - collection: MD96-5722_x_Spencer.gen.Akond_Liu_2014
-      synopsis: "Identification of Quantitative Trait Loci (QTL) Underlying Protein, Oil, and Five Major Fatty Acids’ Contents in Soybean"
-    - collection: MD96-5722_x_Spencer.gen.Anderson_Akond_2015
-      synopsis: "Quantitative trait loci underlying resistance to sudden death syndrome (SDS) in MD96-5722 by ‘Spencer’ recombinant inbred line population of soybean"
     - collection: Merit_x_PI194639.gen.Vuong_Diers_2008
       synopsis: "Identification of QTL for Resistance to Sclerotinia Stem Rot in Soybean Plant Introduction 194639"
-    - collection: MFS-553_x_PI243545.gen.Zeng_Chen_2014
-      synopsis: "Identification of Quantitative Trait Loci for Sucrose Content in Soybean Seed"
     - collection: Minsoy_x_Archer.gen.Orf_Chase_1999a
       synopsis: "Genetics of Soybean Agronomic Traits: II. Interactions between Yield Quantitative Trait Loci in Soybean"
     - collection: Minsoy_x_Archer.gen.Orf_Chase_1999b
@@ -411,62 +413,6 @@ species:
       synopsis: "Quantitative Trait Locus Analysis of Flowering Time in Soybean Using a RFLP Linkage Map."
     - collection: Misuzudaizu_x_MoshidouGong503MG503.gen.Githiri_Watanabe_2006
       synopsis: "QTL analysis of flooding tolerance in soybean at an early vegetative growth stage"
-    - collection: mixed.gen.Glover_Wang_2004
-      synopsis: "Near Isogenic Lines Confirm a Soybean Cyst Nematode Resistance Gene from PI 88788 on Linkage Group J"
-    - collection: mixed.gen.Hwang_King_2016
-      synopsis: "Meta-analysis to refine map position and reduce confidence intervals for delayed-canopy-wilting QTLs in soybean"
-    - collection: mixed.gen.Jun_Van_2008
-      synopsis: "Association analysis using SSR markers to find QTL for seed protein content in soybean"
-    - collection: mixed.gen.Matthews_MacDonald_1998
-      synopsis: "Molecular markers residing close to the Rhg4 locus conferring resistance to soybean cyst nematode race 3 on linkage group A of soybean"
-    - collection: mixed.gen.Meksem_Ruben_2001
-      synopsis: "Conversion of AFLP bands into high-throughput DNA markers"
-    - collection: mixed.gen.Mudge_Cregan_1997
-      synopsis: "Two Microsatellite Markers That Flank the Major Soybean Cyst Nematode Resistance Locus"
-    - collection: mixed.gen.Pathan_Vuong_2013
-      synopsis: "Genetic Mapping and Confirmation of Quantitative Trait Loci for Seed Protein and Oil Contents and Seed Weight in Soybean"
-    - collection: mixed.gen.Qi_Wu_2011
-      synopsis: "Soybean oil content QTL mapping and integrating with meta-analysis method for mining genes"
-    - collection: mixed.gwas.Bandillo_Jarquin_2015
-      synopsis: "GWAS of soybean seed protein and oil, using 12,000 accessions from the USDA soybean collection and the SoySNP50K BeadChip."
-    - collection: mixed.gwas.Bao_Kurle_2015
-      synopsis: "GWAS of soybean sudden death syndrome (SDS), based on 282 breeding lines, genotyped with the 1536-SNP USLP1.0 chip."
-    - collection: mixed.gwas.Cao_Li_2017
-      synopsis: "GWAS and QTL study of soybean seed oil, conducted on 279 lines from a Chinese breeding population, genotyped with 59,845 SNPs."
-    - collection: mixed.gwas.Chang_Brown_2016
-      synopsis: "GWAS of Tobacco ringspot virus (TRSV) conducted on 19,652 lines in the USDA Soybean Collection, genotyped with the SoySNP50K BeadChip."
-    - collection: mixed.gwas.Che_Liu_2017
-      synopsis: "GWAS of Soybean mosaic virus (SMV), conducted on 165 lines from parents with differing susceptibility, genotyped with the NJAU 355K Soy SNP assay."
-    - collection: mixed.gwas.Dhanapal_Ray_2016
-      synopsis: "GWAS of soybean chlorophyll traits based on canopy spectral reflectance and leaf extracts."
-    - collection: mixed.gwas.Fang_Ma_2017
-      synopsis: "GWAS of 84 agronomic traits, conducted on 809 soybean accessions, with genotyping by resequencing."
-    - collection: mixed.gwas.Kim_Kim_2020
-      synopsis: "GWAS study of control of flowering time in soybean, genotyped with the 180k Axiom SoyaSNP array."
-    - collection: mixed.gwas.Li_Zhao_2019
-      synopsis: "GWAS study of soybean seed protein and oil, conducted on 298 accessions, genotyped with a panel of 1536 SNPs."
-    - collection: mixed.gwas.Mamidi_Chikara_2011
-      synopsis: "GWAS study of iron deficiency chlorosis (IDC) in soybean, conducted on two populations (n=143, n=141), genotyped with the 1536 SNP USLP1 array."
-    - collection: mixed.gwas.Meng_He_2016
-      synopsis: "Utilizing an innovative GWAS in CSLRP, 44 QTL 199 alleles with 72.2 % contribution to SIFC variation were detected and organized into a QTL-allele matrix for cross design and gene annotation."
-    - collection: mixed.gwas.Moellers_Singh_2017
-      synopsis: "GWAS study of Sclerotinia stem rot (SSR) in soybean, conducted on 466 accessions, genotyped with the SoySNP50K BeadChip."
-    - collection: mixed.gwas.Sonah_ODonoughue_2015
-      synopsis: "GWAS study of eight traits in soybean, conducted on 139 accessions, genotyped using GBS-derived markers."
-    - collection: mixed.gwas.Wang_Chu_2016
-      synopsis: "GWAS study of domestication-related traits in soybean, conducted on 105 wild and 262 cultivated soybeans, genotyped using the NJAU 355K SoySNP array."
-    - collection: mixed.gwas.Yan_Hofmann_2017
-      synopsis: "GWAS study of seed weight in soybean, conducted on 166 from the USDA soybean collection, genotyped using the SoySNP50K BeadChip."
-    - collection: mixed.gwas.Zhang_Hao_2015
-      synopsis: "GWAS study of architecture and yield-related traits in soybean, conducted on 219 accessions, genotyped using the 1536-SNP USLP1 array."
-    - collection: mixed.gwas.Zhang_Song_2015
-      synopsis: "GWAS study of flowering time, maturity dates and plant height in soybean, conducted on 309 soybean accessions, genotyped using the SoySNP50K BeadChip."
-    - collection: mixed.gwas.Zhang_Song_2016
-      synopsis: "GWAS study of seed weight in soybean, conducted on 309 soybean accessions, genotyped using the SoySNP50K BeadChip."
-    - collection: mixed.gwas.Zhao_Teng_2017
-      synopsis: "The aim of the present study was to investigate the genome-wide genetic architecture of resistance to SCN HG Type 2.5.7 (race 1) in landrace and elite cultivated soybeans."
-    - collection: MN1606SP_x_Spencer.gen.Luckew_Swaminathan_2017
-      synopsis: "‘MN1606SP’ by ‘Spencer’ filial soybean population reveals novel quantitative trait loci and interactions among loci conditioning SDS resistance"
     - collection: Msoy8001_x_Conquista.gen.Silva_Schuster_2007
       synopsis: "Validation of microsatellite markers for assisted selection of soybean resistance to cyst nematode races 3 and 14"
     - collection: N87-984-16_x_TN93-99.gen.Panthee_Kwanyuen_2004
@@ -513,26 +459,14 @@ species:
       synopsis: "Genetic control of soybean seed oil: I. QTL and genes associated with seed oil concentration in RIL populations derived from crossing moderately high-oil parents"
     - collection: OACWallace_x_OACGlencoe.gen.Eskandari_Cober_2013b
       synopsis: "Genetic control of soybean seed oil: II. QTL and genes that increase oil concentration without decreasing protein or with increased seed yield"
+    - collection: OX20-8_x_PI398841.gen.Lee_Mian_2013
+      synopsis: "Novel quantitative trait loci for partial resistance to Phytophthora sojae in soybean PI 398841"
     - collection: Ohsuzu_x_PI595926.gen.Kato_Sayama_2014
       synopsis: "A major and stable QTL associated with seed weight in soybean across multiple environments and genetic backgrounds"
     - collection: Osage_x_RA-452.gen.Zeng_Lara_2017
       synopsis: "Quantitative Trait Loci for Chloride Tolerance in ‘Osage’ Soybean"
-    - collection: OX20-8_x_PI398841.gen.Lee_Mian_2013
-      synopsis: "Novel quantitative trait loci for partial resistance to Phytophthora sojae in soybean PI 398841"
     - collection: P9254_x_A97-770012.gen.Charlson_Bailey_2005
       synopsis: "Molecular Marker Satt481 is Associated with Iron‐Deficiency Chlorosis Resistance in a Soybean Breeding Population"
-    - collection: Parker_x_Gsoja.gen.Sebolt_Shoemaker_2000
-      synopsis: "Analysis of a Quantitative Trait Locus Allele from Wild Soybean That Increases Seed Protein Concentration in Soybean"
-    - collection: Peking_x_Essex.gen.Mahalmgam_Skorupska_1995
-      synopsis: "DNA Markers for Resistance to Heterodera glycines I. Race 3 in Soybean Cultivar Peking."
-    - collection: Peking_x_Essex.gen.Qiu_Arelli_1999
-      synopsis: "RFLP markers associated with soybean cyst nematode resistance and seed composition in a ‘Peking’×‘Essex’ population"
-    - collection: Peking_x_Keburi.gen.Song_Han_2010
-      synopsis: "Identification of QTL underlying somatic embryogenesis capacity of immature embryos in soybean (Glycine max (L.) Merr.)"
-    - collection: Peking_x_Tamahomare.gen.Sayama_Nakazaki_2009
-      synopsis: "QTL analysis of seed-flooding tolerance in soybean (Glycine max [L.] Merr.)"
-    - collection: Peking_x_Tamahomare.gen.Yoshikawa_Okumoto_2010
-      synopsis: "Transgressive segregation of isoflavone contents under the control of four QTLs in a cross between distantly related soybean varieties"
     - collection: PI200538_x_CNS.gen.Tamulonis_Luzzi_1997
       synopsis: "DNA marker analysis of loci conferring resistance to peanut root-knot nematode in soybean"
     - collection: PI27890_x_PI290136.gen.Lark_Chase_1995
@@ -543,10 +477,10 @@ species:
       synopsis: "Determining the linkage of quantitative trait loci to RFLP markers using extreme phenotypes of recombinant inbreds of soybean (Glycine max L. Merr.)"
     - collection: PI417479_x_Williams82.gen.Berger_Minor_1999
       synopsis: "An RFLP Marker Associated with Resistance to Phomopsis Seed Decay in Soybean PI 417479"
-    - collection: PI437654_x_Bell.gen.Brucker_Carlson_2005
-      synopsis: "Rhg1 alleles from soybean PI 437654 and PI 88788 respond differentially to isolates of Heterodera glycines in the greenhouse"
     - collection: PI437654_x_BSR101.gen.Webb_Baltazar_1995
       synopsis: "Genetic mapping of soybean cyst nematode race-3 resistance loci in the soybean PI 437.654"
+    - collection: PI437654_x_Bell.gen.Brucker_Carlson_2005
+      synopsis: "Rhg1 alleles from soybean PI 437654 and PI 88788 respond differentially to isolates of Heterodera glycines in the greenhouse"
     - collection: PI437654_x_Essex.gen.Wu_Blake_2009
       synopsis: "QTL, additive and epistatic effects for SCN resistance in PI 437654"
     - collection: PI438489B_x_Hamilton.gen.Bobby_Bazzelle_2012
@@ -581,7 +515,7 @@ species:
       synopsis: "Soybean Quantitative Trait Loci Conditioning Soybean Rust-Induced Canopy Damage"
     - collection: PI68658_x_Lawrence.gen.Fox_Cary_2015
       synopsis: "Confirmation of a Seed Yield QTL in Soybean"
-    - collection: PI88287_x_PI89008.gen.Vaghchhipawala_Bass%C3%BCner_2001
+    - collection: PI88287_x_PI89008.gen.Vaghchhipawala_Bassüner_2001
       synopsis: "Modulations in Gene Expression and Mapping of Genes Associated with Cyst Nematode Infection of Soybean"
     - collection: PI89772_x_Hamilton.gen.Yue_Sleper_2001
       synopsis: "Mapping Resistance to Multiple Races ofHeterodera glycinesin Soybean PI 89772"
@@ -593,6 +527,18 @@ species:
       synopsis: "Molecular markers associated with seed weight in two soybean populations"
     - collection: PI97100_x_Coker237.gen.Mian_Shipe_1997
       synopsis: "RFLP Analysis of Chlorimuron Ethyl Sensitivity in Soybean"
+    - collection: Parker_x_Gsoja.gen.Sebolt_Shoemaker_2000
+      synopsis: "Analysis of a Quantitative Trait Locus Allele from Wild Soybean That Increases Seed Protein Concentration in Soybean"
+    - collection: Peking_x_Essex.gen.Mahalmgam_Skorupska_1995
+      synopsis: "DNA Markers for Resistance to Heterodera glycines I. Race 3 in Soybean Cultivar Peking."
+    - collection: Peking_x_Essex.gen.Qiu_Arelli_1999
+      synopsis: "RFLP markers associated with soybean cyst nematode resistance and seed composition in a ‘Peking’×‘Essex’ population"
+    - collection: Peking_x_Keburi.gen.Song_Han_2010
+      synopsis: "Identification of QTL underlying somatic embryogenesis capacity of immature embryos in soybean (Glycine max (L.) Merr.)"
+    - collection: Peking_x_Tamahomare.gen.Sayama_Nakazaki_2009
+      synopsis: "QTL analysis of seed-flooding tolerance in soybean (Glycine max [L.] Merr.)"
+    - collection: Peking_x_Tamahomare.gen.Yoshikawa_Okumoto_2010
+      synopsis: "Transgressive segregation of isoflavone contents under the control of four QTLs in a cross between distantly related soybean varieties"
     - collection: Pioneer9071_x_8902.gen.Rossi_Orf_2013
       synopsis: "Genetic basis of soybean adaptation to North American vs. Asian mega-environments in two independent populations from Canadian × Chinese crosses"
     - collection: Pioneer9071_x_Line8902.gen.Palomeque_Liu_2010
@@ -617,22 +563,22 @@ species:
       synopsis: "Mapping of Quantitative Trait Loci Associated with Resistance toPhytophthora sojaeand Flooding Tolerance in Soybean"
     - collection: SD02-4-59_x_A02-381100.gen.Wang_Jiang_2012
       synopsis: "Quantitative trait locus analysis of saturated fatty acids in a population of recombinant inbred lines of soybean"
-    - collection: Skylla_x_E00290.gen.Kandel_Chen_2018
-      synopsis: "Soybean Resistance to White Mold: Evaluation of Soybean Germplasm Under Different Conditions and Validation of QTL"
-    - collection: Sowon_x_V94-5152.gen.Jeong_Moon_2011
-      synopsis: "Fine genetic mapping of the genomic region controlling leaflet shape and number of seeds per pod in the soybean"
     - collection: SS-516_x_Camp.gen.Zhang_Chen_2008
       synopsis: "Quantitative Trait Loci Mapping of Seed Hardness in Soybean"
     - collection: SS-516_x_Camp.gen.Zhang_Chen_2009
       synopsis: "Putative Quantitative Trait Loci Associated with Calcium Content in Soybean Seed"
+    - collection: Skylla_x_E00290.gen.Kandel_Chen_2018
+      synopsis: "Soybean Resistance to White Mold: Evaluation of Soybean Germplasm Under Different Conditions and Validation of QTL"
+    - collection: Sowon_x_V94-5152.gen.Jeong_Moon_2011
+      synopsis: "Fine genetic mapping of the genomic region controlling leaflet shape and number of seeds per pod in the soybean"
     - collection: Su88-M21S_x_XinyixiaoheidouX.gen.Wu_Zhou_2011
       synopsis: "Identification of quantitative trait loci for partial resistance to Phytophthora sojae in soybean"
+    - collection: TK780_x_Hidaka4.gen.Shibata_Takayama_2008
+      synopsis: "Genetic relationship between lipid content and linolenic acid concentration in soybean seeds"
     - collection: Taekwangkong_x_SS2-2.gen.Sun_Kim_2013a
       synopsis: "QTLs for resistance to Phomopsis seed decay are associated with days to maturity in soybean (Glycine max)"
     - collection: Taekwangkong_x_SS2-2.gen.Sun_Kim_2013b
       synopsis: "QTLs for resistance to Phomopsis seed decay are associated with days to maturity in soybean (Glycine max)"
-    - collection: TK780_x_Hidaka4.gen.Shibata_Takayama_2008
-      synopsis: "Genetic relationship between lipid content and linolenic acid concentration in soybean seeds"
     - collection: Tokei758_x_To-8E.gen.Sayama_Hwang_2010
       synopsis: "Mapping and comparison of quantitative trait loci for soybean branching phenotype in two locations"
     - collection: Toyoharuka_x_Toyomusume.gen.Ohnishi_Funatsuki_2011
@@ -693,12 +639,66 @@ species:
       synopsis: "Molecular Markers Associated with Water Use Efficiency and Leaf Ash in Soybean"
     - collection: ZDD09454_x_Yudou12.gen.Lu_Wen_2013
       synopsis: "Identification of the quantitative trait loci (QTL) underlying water soluble protein content in soybean"
-    - collection: Zhongdou27_x_Jiunong20.gen.Meng_Han_2011
-      synopsis: "QTL underlying the resistance to soybean aphid (Aphis glycines Matsumura) through isoflavone-mediated antibiosis in soybean cultivar ‘Zhongdou 27’"
     - collection: ZhongDou27_x_JiuNong20.gen.Wang_Han_2015
       synopsis: "Mapping Isoflavone QTL with Main, Epistatic and QTL × Environment Effects in Recombinant Inbred Lines of Soybean"
+    - collection: Zhongdou27_x_Jiunong20.gen.Meng_Han_2011
+      synopsis: "QTL underlying the resistance to soybean aphid (Aphis glycines Matsumura) through isoflavone-mediated antibiosis in soybean cultivar ‘Zhongdou 27’"
     - collection: Zhongdou27_x_Jiunong20.gen.Zeng_Li_2009
       synopsis: "Identification of QTL underlying isoflavone contents in soybean seeds among multiple environments"
+    - collection: mixed.gen.Glover_Wang_2004
+      synopsis: "Near Isogenic Lines Confirm a Soybean Cyst Nematode Resistance Gene from PI 88788 on Linkage Group J"
+    - collection: mixed.gen.Hwang_King_2016
+      synopsis: "Meta-analysis to refine map position and reduce confidence intervals for delayed-canopy-wilting QTLs in soybean"
+    - collection: mixed.gen.Jun_Van_2008
+      synopsis: "Association analysis using SSR markers to find QTL for seed protein content in soybean"
+    - collection: mixed.gen.Matthews_MacDonald_1998
+      synopsis: "Molecular markers residing close to the Rhg4 locus conferring resistance to soybean cyst nematode race 3 on linkage group A of soybean"
+    - collection: mixed.gen.Meksem_Ruben_2001
+      synopsis: "Conversion of AFLP bands into high-throughput DNA markers"
+    - collection: mixed.gen.Mudge_Cregan_1997
+      synopsis: "Two Microsatellite Markers That Flank the Major Soybean Cyst Nematode Resistance Locus"
+    - collection: mixed.gen.Pathan_Vuong_2013
+      synopsis: "Genetic Mapping and Confirmation of Quantitative Trait Loci for Seed Protein and Oil Contents and Seed Weight in Soybean"
+    - collection: mixed.gen.Qi_Wu_2011
+      synopsis: "Soybean oil content QTL mapping and integrating with meta-analysis method for mining genes"
+    - collection: mixed.gwas.Bandillo_Jarquin_2015
+      synopsis: "GWAS of soybean seed protein and oil, using 12,000 accessions from the USDA soybean collection and the SoySNP50K BeadChip."
+    - collection: mixed.gwas.Bao_Kurle_2015
+      synopsis: "GWAS of soybean sudden death syndrome (SDS), based on 282 breeding lines, genotyped with the 1536-SNP USLP1.0 chip."
+    - collection: mixed.gwas.Cao_Li_2017
+      synopsis: "GWAS and QTL study of soybean seed oil, conducted on 279 lines from a Chinese breeding population, genotyped with 59,845 SNPs."
+    - collection: mixed.gwas.Chang_Brown_2016
+      synopsis: "GWAS of Tobacco ringspot virus (TRSV) conducted on 19,652 lines in the USDA Soybean Collection, genotyped with the SoySNP50K BeadChip."
+    - collection: mixed.gwas.Che_Liu_2017
+      synopsis: "GWAS of Soybean mosaic virus (SMV), conducted on 165 lines from parents with differing susceptibility, genotyped with the NJAU 355K Soy SNP assay."
+    - collection: mixed.gwas.Dhanapal_Ray_2016
+      synopsis: "GWAS of soybean chlorophyll traits based on canopy spectral reflectance and leaf extracts."
+    - collection: mixed.gwas.Fang_Ma_2017
+      synopsis: "GWAS of 84 agronomic traits, conducted on 809 soybean accessions, with genotyping by resequencing."
+    - collection: mixed.gwas.Kim_Kim_2020
+      synopsis: "GWAS study of control of flowering time in soybean, genotyped with the 180k Axiom SoyaSNP array."
+    - collection: mixed.gwas.Li_Zhao_2019
+      synopsis: "GWAS study of soybean seed protein and oil, conducted on 298 accessions, genotyped with a panel of 1536 SNPs."
+    - collection: mixed.gwas.Mamidi_Chikara_2011
+      synopsis: "GWAS study of iron deficiency chlorosis (IDC) in soybean, conducted on two populations (n=143, n=141), genotyped with the 1536 SNP USLP1 array."
+    - collection: mixed.gwas.Meng_He_2016
+      synopsis: "Utilizing an innovative GWAS in CSLRP, 44 QTL 199 alleles with 72.2 % contribution to SIFC variation were detected and organized into a QTL-allele matrix for cross design and gene annotation."
+    - collection: mixed.gwas.Moellers_Singh_2017
+      synopsis: "GWAS study of Sclerotinia stem rot (SSR) in soybean, conducted on 466 accessions, genotyped with the SoySNP50K BeadChip."
+    - collection: mixed.gwas.Sonah_ODonoughue_2015
+      synopsis: "GWAS study of eight traits in soybean, conducted on 139 accessions, genotyped using GBS-derived markers."
+    - collection: mixed.gwas.Wang_Chu_2016
+      synopsis: "GWAS study of domestication-related traits in soybean, conducted on 105 wild and 262 cultivated soybeans, genotyped using the NJAU 355K SoySNP array."
+    - collection: mixed.gwas.Yan_Hofmann_2017
+      synopsis: "GWAS study of seed weight in soybean, conducted on 166 from the USDA soybean collection, genotyped using the SoySNP50K BeadChip."
+    - collection: mixed.gwas.Zhang_Hao_2015
+      synopsis: "GWAS study of architecture and yield-related traits in soybean, conducted on 219 accessions, genotyped using the 1536-SNP USLP1 array."
+    - collection: mixed.gwas.Zhang_Song_2015
+      synopsis: "GWAS study of flowering time, maturity dates and plant height in soybean, conducted on 309 soybean accessions, genotyped using the SoySNP50K BeadChip."
+    - collection: mixed.gwas.Zhang_Song_2016
+      synopsis: "GWAS study of seed weight in soybean, conducted on 309 soybean accessions, genotyped using the SoySNP50K BeadChip."
+    - collection: mixed.gwas.Zhao_Teng_2017
+      synopsis: "The aim of the present study was to investigate the genome-wide genetic architecture of resistance to SCN HG Type 2.5.7 (race 1) in landrace and elite cultivated soybeans."
   genomes:
     - collection: FiskebyIII.gnm1.F177
       synopsis: "Glycine max genotype Fiskeby III genome assembly v1.0"
@@ -749,12 +749,12 @@ species:
       synopsis: "NJAU 355K SoySNP array used to study soybean domestication in Wang, et al. (2016)."
     - collection: Wm82.gnm2.mrk.Sonah_ODonoughue_2015
       synopsis: "GWAS study of eight traits in soybean, conducted on 139 accessions, genotyped using GBS-derived markers."
-    - collection: Wm82.gnm2.mrk.SoyaSNP180K
-      synopsis: "Axiom SoyaSNP180K array with 180,981 SNPs developed by Lee, et al. (2015)."
     - collection: Wm82.gnm2.mrk.SoySNP50K
       synopsis: "SoySNP50K is an Illumina Infinium II BeadChip that contains over 50,000 SNPs from soybean useful for genotyping a wide variety of cultivated and wild soybean accessions."
     - collection: Wm82.gnm2.mrk.SoySNP6K
       synopsis: "Illumina Infinium SoySNP6K BeadChip"
+    - collection: Wm82.gnm2.mrk.SoyaSNP180K
+      synopsis: "Axiom SoyaSNP180K array with 180,981 SNPs developed by Lee, et al. (2015)."
     - collection: Wm82.gnm2.mrk.Zhao_Teng_2017
       synopsis: "A total of 200 diverse soybean accessions were screened for resistance to SCN HG Type 2.5.7 and genotyped through sequencing using SLAF-seq. A total of 33,194 SNPs were identified with minor allele frequencies (MAF) over 4%, covering 97% of all the genotypes."
 - name: soja
@@ -765,8 +765,6 @@ species:
       synopsis: "Glycine soja accession PI483463 genome annotation files; JGI annotation version 1 on assembly 1"
     - collection: W05.gnm1.ann1.T47J
       synopsis: "Glycine soja accession W05 genome annotation files"
-  diversity:
-  expression:
   genetic:
     - collection: mixed.gwas.Hu_Zhang_2014
       synopsis: "GWAS of soybean yield-related traits, conducted on 113 wild soybean accessions, genotyped with 85 simple sequence repeat (SSR) markers."
@@ -777,70 +775,45 @@ species:
       synopsis: "Glycine soja accession PI 483463 genome assembly, v1.0"
     - collection: W05.gnm1.SVL1
       synopsis: "Genome assembly files for cultivar W05 from Xie, Lam et al. (2019): A reference-grade wild soybean genome"
-  markers:
 - name: cyrtoloba
   annotations:
     - collection: G1267.gnm1.ann1.HRFD
       synopsis: "Genome annotation files for Glycine cyrtoloba, accession G1267, from Zhuang, Wang et al. (2021)"
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: G1267.gnm1.YWW6
       synopsis: "Genome assemblies for Glycine cyrtoloba, accession G1267, from Zhuang, Wang et al. (2021)"
-  markers:
 - name: dolichocarpa
   annotations:
     - collection: G1134.gnm1.ann1.4BJM
       synopsis: "Genome annotation files for Glycine tolichocarpa, accession G1134, from Zhuang, Wang et al. (2021)"
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: G1134.gnm1.PP7B
       synopsis: "Genome assemblies for Glycine dolichocarpa, accession G1134, from Zhuang, Wang et al. (2021)"
-  markers:
 - name: falcata
   annotations:
     - collection: G1718.gnm1.ann1.2KSV
       synopsis: "Genome annotation files for Glycine falcata, accession G1718, from Zhuang, Wang et al. (2021)"
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: G1718.gnm1.B1PY
       synopsis: "Genome assemblies for Glycine falcata, accession G1718, from Zhuang, Wang et al. (2021)"
-  markers:
 - name: stenophita
   annotations:
     - collection: G1974.gnm1.ann1.F257
       synopsis: "Genome annotation files for Glycine stenphyta, accession G1974, from Zhuang, Wang et al. (2021)"
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: G1974.gnm1.7MZB
       synopsis: "Genome assemblies for Glycine stenophita, accession G1974, from Zhuang, Wang et al. (2021)"
-  markers:
 - name: syndetika
   annotations:
     - collection: G1300.gnm1.ann1.RRK6
       synopsis: "Genome annotation files for Glycine syndetika, accession G1300, from Zhuang, Wang et al. (2021)"
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: G1300.gnm1.C11H
       synopsis: "Genome assemblies for Glycine syndetika, accession G1300, from Zhuang, Wang et al. (2021)"
-  markers:
 - name: D3-tomentella
   annotations:
     - collection: G1403.gnm1.ann1.XNZQ
       synopsis: "Genome annotation files for Glycine D3 tomentella, accession G1403, from Zhuang, Wang et al. (2021)"
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: G1403.gnm1.CL6K
       synopsis: "Genome assemblies for Glycine D3 tomentella, accession G1403, from Zhuang, Wang et al. (2021)"
-  markers:

--- a/_data/taxa/Glycine/species_resources.yml
+++ b/_data/taxa/Glycine/species_resources.yml
@@ -152,7 +152,7 @@ species:
   - URL: https://soybase.org/gcvit
     description: 'Genotype comparison visualization tool '
     name: GCViT
-  - URL: https://gcv.legumeinfo.org/gene;lis=glyma.Glyma.15G255600?q=Glyma.15G255600&sources=lis&algorithm=repeat&match=10&mismatch=-1&gap=-1&score=30&threshold=25&bmatched=20&bintermediate=10&bmask=10&linkage=average&cthreshold=20&neighbors=10&matched=4&intermediate=5&bregexp=&border=chromosome&regexp=&order=distance
+  - URL: https://gcv.legumeinfo.org/gene;lis=glyso.PI483463.gnm1.ann1.GlysoPI483463.08G318500
     description: Browser for dynamically discovering and viewing genomic synteny across
       selected species.
     name: Genome Context Viewer

--- a/_data/taxa/Lotus/species_collections.yml
+++ b/_data/taxa/Lotus/species_collections.yml
@@ -4,10 +4,6 @@ species:
   annotations:
     - collection: MG20.gnm3.ann1.WF9B
       synopsis: "Genome annotation of Lotus japonicus (MG20 variety)"
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: MG20.gnm3.QPGB
       synopsis: "Genome assembly of Lotus japonicus (MG20 variety)"
-  markers:

--- a/_data/taxa/Lupinus/species_collections.yml
+++ b/_data/taxa/Lupinus/species_collections.yml
@@ -4,21 +4,13 @@ species:
   annotations:
     - collection: Amiga.gnm1.ann1.3GKS
       synopsis: "Lupinus albus accession Amiga annotation files on genome assembly version 1"
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: Amiga.gnm1.F4NR
       synopsis: "genome assembly, including both nuclear pseudomolecules, unplaced contigs and organelle sequences"
-  markers:
 - name: angustifolius
   annotations:
     - collection: Tanjil.gnm1.ann1.nnV9
       synopsis: "genome annotation files"
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: Tanjil.gnm1.Qq0N
       synopsis: "Genome assembly, including scaffold assemblies, pseudomolecule assemblies, and information for anchoring scaffolds into pseudomolecules for Lupinus angustifolius (Tanjil)."
-  markers:

--- a/_data/taxa/Medicago/genus_resources.yml
+++ b/_data/taxa/Medicago/genus_resources.yml
@@ -20,11 +20,11 @@ resources:
   description: InterMine interface for accessing genetic and genomic data for several
     species in Medicago.
   name: MedicMine
-- URL: https://www.legumeinfo.org/gcv2/gene;lis=medtr.Medtr1g009230?q=medtr.chr1:1000000-1500000&sources=lis&algorithm=repeat&match=10&mismatch=-1&gap=-1&score=30&threshold=25&bmatched=20&bintermediate=10&bmask=10&linkage=average&cthreshold=20&neighbors=61&matched=4&intermediate=5&bregexp=&border=chromosome&regexp=&order=distance
+- URL: https://gcv.legumeinfo.org/gene;lis=medtr.A17_HM341.gnm4.ann2.Medtr1g009230
   description: Browser for dynamically discovering and viewing genomic synteny across
     selected species.
   name: Genome Context Viewer
-- URL: https://www.legumeinfo.org/germplasm/map#?zoom=6&maxRecs=200&taxonQuery=Medicago&traitScale=global&geocodedOnly=false&traitExcludeUnchar=false&limitToMapExtent=false&lat=35.87&lng=-109.47&mapHeight=188.25&baseMap=ESRI%20-%20NatGeo%20(default,%20reference%20map)&ne_lat=37.52715361723378&ne_lng=-93.97705078125001&sw_lat=34.17999758688084&sw_lng=-124.95849609375001&accessionIdsInclusive=false
+- URL: https://legacy.legumeinfo.org/germplasm/map#?zoom=6&maxRecs=200&taxonQuery=Medicago&traitScale=global&geocodedOnly=false&traitExcludeUnchar=false&limitToMapExtent=false&lat=35.87&lng=-109.47&mapHeight=188.25&baseMap=ESRI%20-%20NatGeo%20(default,%20reference%20map)&ne_lat=37.52715361723378&ne_lng=-93.97705078125001&sw_lat=34.17999758688084&sw_lng=-124.95849609375001&accessionIdsInclusive=false
   description: Geographic information system viewer, showing collection locations
     for Medicago data held by the U.S. National Plant Germplasm System.
   name: Germplasm GIS

--- a/_data/taxa/Medicago/species_collections.yml
+++ b/_data/taxa/Medicago/species_collections.yml
@@ -7,8 +7,6 @@ species:
   diversity:
     - collection: mixed.tcp.div.Li_Acharya_2012
       synopsis: "genotype variants called with respect to a transcriptome assembly, from 27 alfalfa genotypes, from Li, Acharya et al., 2012"
-  expression:
-  genetic:
   genomes:
     - collection: CADL_HM342.gnm1.rVNY
       synopsis: "Genome assembly of Medicago sativa CADL (HM342)"
@@ -16,7 +14,6 @@ species:
       synopsis: "Genome assembly of Medicago sativa RegenSY27x"
     - collection: XinJiangDaYe.gnm1.12MR
       synopsis: "Pseudomolecule assemblies and scaffolds representing 4 haplotypes per chromosome for Medicago sativa XinJiangDaYe"
-  markers:
 - name: truncatula
   annotations:
     - collection: A17.gnm5.ann1_6.L2RX
@@ -51,6 +48,8 @@ species:
       synopsis: "Genome annotation for Medicago truncatula (HM185)"
     - collection: HM324.gnm1.ann1.SQH2
       synopsis: "Genome annotation for Medicago truncatula (HM324)"
+    - collection: R108.gnmHiC_1.ann1.Y8NH
+      synopsis: "An assembly based on the earlier PacBio-based genome (R108_HM340.gnm1.XT6J), put into pseudomolecules using HiC scaffolding."
     - collection: R108_HM340.gnm1.ann1.85YW
       synopsis: "Genome annotation for Medicago truncatula R108 (HM340)"
   diversity:
@@ -61,7 +60,6 @@ species:
   expression:
     - collection: A17_HM341.gnm4.ann2.expr.RLZY
       synopsis: "Affymetrix GeneChip expression data from the Noble Medicago truncatula Gene Expression Atlas"
-  genetic:
   genomes:
     - collection: A17.gnm5.MVZ2
       synopsis: "Scaffold assemblies and pseudomolecule assemblies for Medicago truncatula A17"
@@ -113,4 +111,3 @@ species:
       synopsis: "An assembly based on the earlier PacBio-based genome (R108_HM340.gnm1.XT6J), put into pseudomolecules using HiC scaffolding."
     - collection: R108_HM340.gnm1.XT6J
       synopsis: "Genome assembly for Medicago truncatula R108 (HM340)"
-  markers:

--- a/_data/taxa/Phaseolus/species_collections.yml
+++ b/_data/taxa/Phaseolus/species_collections.yml
@@ -4,13 +4,9 @@ species:
   annotations:
     - collection: G27455.gnm1.ann1.JD7C
       synopsis: "Phaseolus lunatus accession G27455 annotation files from genome assembly V1"
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: G27455.gnm1.7NXX
       synopsis: "Phaseolus lunatus accession G27455 genome assembly V1"
-  markers:
 - name: vulgaris
   annotations:
     - collection: 5-593.gnm1.ann1.3FBJ
@@ -30,7 +26,7 @@ species:
     - collection: G19833.gnm1.ann1.expr.4ZDQ
       synopsis: "LIS expression dataset phavu1 (An RNA-Seq based gene expression atlas of the common bean cv. Negro jamapa)."
   genetic:
-    - collection: BAT93_x_JALOEEP558.gen.Blair_Cort%C3%A9s_2018
+    - collection: BAT93_x_JALOEEP558.gen.Blair_Cortés_2018
       synopsis: "This BAT93 x JALOEEP558 map was constructed using Mapdisto v. 2.0 (Lorieux, 2012), assuming an RI model and using the create groups command both with and without anchor markers."
     - collection: BAT93_x_JALOEEP558.gen.Caldas_Blair_2009
       synopsis: "Three RIL populations were used to find QTLs for seed color."
@@ -46,7 +42,11 @@ species:
       synopsis: "The G2333_x_G19839_a genetic map contains all 11 common bean linkage groups.  It has a total length of 1175 cM and 149 mapped total markers."
     - collection: ICABunsi_x_SXB405.gen.Parker_BernyMierYTeran_2020
       synopsis: "Pod Dehiscence QTLs were identified using three phenotyping methods and an ICA Bunsi (PD-susceptible) x SXB 405 (PD-resistant) recombinant inbred mapping population."
-    - collection: mixed.gen.Blair_Cort%C3%A9s_2018
+    - collection: Stampede_x_RedHawk.gen.Song_Jia_2015
+      synopsis: "A mapping population of 267 F2 plants from the cross of common bean varieties Stampede and Red Hawk developed by Dr. Phil McClean at North Dakota State University."
+    - collection: Xana_x_Cornell49242.gen.Gaitán-Solís_Duque_2002
+      synopsis: "A map of 175 AFLP, 27 microsatellite, 30 SCAR, 33 ISSR, and 12 RAPD markers, as well as 13 loci coding for seed proteins, and four traditional genes (Fin/fin for growth habit, Asp/asp for seed coat shininess, P/p for seed color, and I/i for resistance to bean common mosaic virus)."
+    - collection: mixed.gen.Blair_Cortés_2018
       synopsis: "Genetic map of markers to Phaseolus vulgaris accession G19833 genome assembly v1.0"
     - collection: mixed.gen.Galeano_Fernandez_2011
       synopsis: "This common bean consensus map was created using the DB (DOR364_x_BAT477, Mesoamerican intra-gene pool cross), DG (DOR364_x_G19833, inter-gene pool cross), and BJ (BAT93_x_JALOEEP558, inter-gene pool cross) mapping populations."
@@ -70,10 +70,6 @@ species:
       synopsis: "GWAS of agronomic, architecture, and biotic stress traits at different locations within China for Common bean, relative to the G19833 assembly 1.0."
     - collection: mixed.gwas.Zitnick-Anderson_Oladzad_2020
       synopsis: "GWAS of Fusarium root rot resistance in Common Bean, relative to the G19833 assembly 2."
-    - collection: Stampede_x_RedHawk.gen.Song_Jia_2015
-      synopsis: "A mapping population of 267 F2 plants from the cross of common bean varieties Stampede and Red Hawk developed by Dr. Phil McClean at North Dakota State University."
-    - collection: Xana_x_Cornell49242.gen.Gait%C3%A1n-Sol%C3%ADs_Duque_2002
-      synopsis: "A map of 175 AFLP, 27 microsatellite, 30 SCAR, 33 ISSR, and 12 RAPD markers, as well as 13 loci coding for seed proteins, and four traditional genes (Fin/fin for growth habit, Asp/asp for seed coat shininess, P/p for seed color, and I/i for resistance to bean common mosaic virus)."
   genomes:
     - collection: 5-593.gnm1.1P7P
       synopsis: "Phaseolus vulgaris accession 5-593 (Middle American race), genome assembly v1."
@@ -132,12 +128,8 @@ species:
       synopsis: "Genome annotation files for Phaseolus acutifolius accession Frijol Bayo; JGI annotation version 1 on assembly 1"
     - collection: W6_15578.gnm2.ann1.LVZ1
       synopsis: "Phaseolus acutifolius accession W6_15578, annotations on genome assembly v2."
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: Frijol_Bayo.gnm1.QH8L
       synopsis: "Phaseolus acutifolius accession Frijol Bayo, genome assembly v1."
     - collection: W6_15578.gnm2.L2V4
       synopsis: "Phaseolus acutifolius accession W6_15578, genome assembly v2."
-  markers:

--- a/_data/taxa/Pisum/species_collections.yml
+++ b/_data/taxa/Pisum/species_collections.yml
@@ -4,10 +4,6 @@ species:
   annotations:
     - collection: Cameor.gnm1.ann1.7SZR
       synopsis: "Pisum sativum accession Cameor annotation files on genome assembly version 1a"
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: Cameor.gnm1.P4FG
       synopsis: "Pisum sativum accession Cameor genome assembly version 1a"
-  markers:

--- a/_data/taxa/Trifolium/species_collections.yml
+++ b/_data/taxa/Trifolium/species_collections.yml
@@ -4,10 +4,6 @@ species:
   annotations:
     - collection: MilvusB.gnm2.ann1.DFgp
       synopsis: "Genome assembly for Trifolium pratense (Milvus B)"
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: MilvusB.gnm2.gNmT
       synopsis: "Genome assembly for Trifolium pratense (Milvus B)"
-  markers:

--- a/_data/taxa/Vigna/genus_resources.yml
+++ b/_data/taxa/Vigna/genus_resources.yml
@@ -12,7 +12,7 @@ resources:
 - URL: https://zzbrowse.legumeinfo.org/?tab=WhGen&datasets=Cowpea%20GWAS&chr=Vu01&selected=100000&window=250000&datasets2=Soybean%20GWAS&chr2=Gm01&selected2=100000&window2=250000&macroMatched=20&macroIntermediate=10&macroMask=10&macroDistance=levenshtein
   description: Association viewers (QTL, GWAS)
   name: ZZBrowse
-- URL: https://legacy.legumeinfo.org/germplasm/map#?zoom=6&maxRecs=200&taxonQuery=Vigna&traitScale=global&geocodedOnly=false&traitExcludeUnchar=false&limitToMapExtent=false&lat=35.88&lng=-109.47&mapHeight=164.75&baseMap=ESRI%20-%20NatGeo%20(default,%20reference%20map)&ne_lat=37.33522435930639&ne_lng=-93.97705078125001&sw_lat=34.397844946449865&sw_lng=-124.95849609375001&accessionIdsInclusive=false
+- URL: https://gcv.legumeinfo.org/gene;lis=vigun.IT97K-499-35.gnm1.ann2.Vigun05g001800
   description: Browser for dynamically discovering and viewing genomic synteny across
     selected species.
   name: Genome Context Viewer

--- a/_data/taxa/Vigna/species_collections.yml
+++ b/_data/taxa/Vigna/species_collections.yml
@@ -6,15 +6,11 @@ species:
       synopsis: "Directory of gene annotations, called on an assembly of pseudomolecules and remaining scaffold sequences"
     - collection: Shumari.gnm1.ann1.8BRS
       synopsis: "Vigna angularis accession Shumari genome annotation files"
-  diversity:
-  expression:
-  genetic:
   genomes:
     - collection: Gyeongwon.gnm3.JyYC
       synopsis: "genome assembly"
     - collection: Shumari.gnm1.V0CS
       synopsis: "Vigna angularis accession Shumari genome"
-  markers:
 - name: radiata
   annotations:
     - collection: VC1973A.gnm6.ann1.M1Qs
@@ -22,7 +18,6 @@ species:
   diversity:
     - collection: VC1973A.gnm6.div.Sandhu_Singh_2020
       synopsis: "Genetic variants for Vigna radiata, assessed across 500 accessions to create the Iowamung bean panel; genotyped relative to accession VC1973A.gnm6"
-  expression:
   genetic:
     - collection: IA_panel.gwas.Sandhu_Singh_2020
       synopsis: "Strategies for the utilization of the USDA mung bean germplasm collection for breeding outcomes"
@@ -30,11 +25,11 @@ species:
     - collection: VC1973A.gnm6.3nL8
       synopsis: "Directory of scaffold assemblies and pseudomolecule assemblies."
   markers:
-    - collection: VC1973A.gnm6.mrk.microsatellites
-      synopsis: "SSR markers and genomic locations on the genome sequence of Vigna radiata, accession VC1973A"
     - collection: VC1973A.gnm6.mrk.Sandhu_Singh_2020
       synopsis: "Genotyping with the 51,128 single nucleotide polymorphism (SNP) Illumina iSelect BeadArray resulted in 36,346 SNPs that were polymorphic between the eight parents (68.26%)."
     - collection: VC1973A.gnm6.mrk.TG34
+      synopsis: "SSR markers and genomic locations on the genome sequence of Vigna radiata, accession VC1973A"
+    - collection: VC1973A.gnm6.mrk.microsatellites
       synopsis: "SSR markers and genomic locations on the genome sequence of Vigna radiata, accession VC1973A"
 - name: unguiculata
   annotations:
@@ -69,26 +64,26 @@ species:
       synopsis: "Field-based assays for genetic mapping involved 92 F8 RILs derived from a cross of cowpea aphid-susceptible CB27 and aphid-resistant breeding line IT97K556-6."
     - collection: CB46_x_IT93K-503-1.gen.Pottorff_Li_2014
       synopsis: "MSTmap genotype file containing calls for 113 F10 RILs descended from IT93K-503-1 (resistant) and CB46 (susceptible) for a study of Fot race 4 resistance."
-    - collection: iSelect-consensus-2016.gen.Mu%C3%B1oz-Amatria%C3%ADn_Mirebrahim_2017
-      synopsis: "Illumina Cowpea iSelect Consortium Array, built from 37 cowpea accessions"
     - collection: IT84S-2246-4_x_TVu-14676.gen.Pottorff_Roberts_2014
       synopsis: "Genotype file containing calls for 136 F8 RILs from IT84S-2246 x TVu-14676 for a study of heat-induced browning of seed coats."
-    - collection: IT99K-573-1-1_x_TVNu-1158.gen.Lo_Mu%C3%B1oz-Amatria%C3%ADn_2018
+    - collection: IT99K-573-1-1_x_TVNu-1158.gen.Lo_Muñoz-Amatriaín_2018
       synopsis: "215 F8 RILs developed from the cultivated (IT99K-573-1-1) and wild-type (TVNu-1158) accessions were used in mapping to study domestication-related traits."
     - collection: MAGIC-2017.gen.Huynh_Ehlers_2018
       synopsis: "A MAGIC population for cowpea developed from eight founder parents."
-    - collection: mixed.gen.Burridge_Schneider_2017
-      synopsis: "A 189-entry diversity panel was used to study root architecture phenes."
-    - collection: mixed.gen.Herniter_Mu%C3%B1oz-Amatria%C3%ADn_2018
-      synopsis: "Four populations were used to study black seed coat and pod tip color: two biparental RIL populations, the UC-Riverside eight-parent MAGIC population, and a diversity minicore population."
-    - collection: mixed.gen.Huynh_Matthews_2016
-      synopsis: "87 RILs from CB27×24-125-B-1; 170 F2:3 families from IT84S-2049×UCR779; 132 F2:3 families from IT93K-503-1×UCR779 are used to study root-knot nematode (RKN) resistance."
-    - collection: mixed.gwas.Lo_Mu%C3%B1oz-Amatria%C3%ADn_2019
-      synopsis: "GWAS of seed size in cowpea, conducted on 368 diverse accessions from 51 countries, genotyped using the Cowpea iSelect array."
     - collection: Sanzi_x_Vita7.gen.Pottorff_Ehlers_2012
       synopsis: "A segregating population of 122 RILs, advanced from Sanzi x Vita 7, reveals a QTL, a candidate gene, and a SNP marker for hastate leaf shape."
     - collection: ZN016_x_Zhijiang282.gen.Xu_Wu_2017
       synopsis: "A novel genotyping assay for over 50,000 SNPs was employed to delineate genomic regions governing cowpea pod length."
+    - collection: iSelect-consensus-2016.gen.Muñoz-Amatriaín_Mirebrahim_2017
+      synopsis: "Illumina Cowpea iSelect Consortium Array, built from 37 cowpea accessions"
+    - collection: mixed.gen.Burridge_Schneider_2017
+      synopsis: "A 189-entry diversity panel was used to study root architecture phenes."
+    - collection: mixed.gen.Herniter_Muñoz-Amatriaín_2018
+      synopsis: "Four populations were used to study black seed coat and pod tip color: two biparental RIL populations, the UC-Riverside eight-parent MAGIC population, and a diversity minicore population."
+    - collection: mixed.gen.Huynh_Matthews_2016
+      synopsis: "87 RILs from CB27×24-125-B-1; 170 F2:3 families from IT84S-2049×UCR779; 132 F2:3 families from IT93K-503-1×UCR779 are used to study root-knot nematode (RKN) resistance."
+    - collection: mixed.gwas.Lo_Muñoz-Amatriaín_2019
+      synopsis: "GWAS of seed size in cowpea, conducted on 368 diverse accessions from 51 countries, genotyped using the Cowpea iSelect array."
   genomes:
     - collection: CB5-2.gnm1.WDTB
       synopsis: "Vigna unguiculata genome assembly for CB5-2"

--- a/_scripts/build
+++ b/_scripts/build
@@ -1,6 +1,0 @@
-#!/bin/sh
-## script to build new _data files
-## requires the latest (python 3.9) versions of pyyaml and requests
-
-python3.9 genus_species_resources.py
-python3.9 genus_species_collections.py

--- a/_scripts/build-data-yaml
+++ b/_scripts/build-data-yaml
@@ -1,0 +1,15 @@
+#!/bin/sh
+## script to build new _data files
+## requires python 3.9+ version of pyyaml
+
+## clone a local copy of the Datastore metadata
+git clone https://github.com/legumeinfo/datastore-metadata
+
+## generate the species_resources YAML files
+python3.9 genus_species_resources.py
+
+## generate the genes_specues_collections YAML files
+python3.9 genus_species_collections.py
+
+## remove the copy of the Datastore metadata
+rm -rf datastore-metadata

--- a/_scripts/genus_species_collections.py
+++ b/_scripts/genus_species_collections.py
@@ -1,64 +1,36 @@
 import yaml
-import requests
-from html.parser import HTMLParser
+import os
 
-DATASTORE_URL = "https://data.legumeinfo.org"
+## This script assumes that datastore-metadata has been cloned in the current directory.
 
-class CollectionsParser(HTMLParser):
-    collections = []
-    def handle_starttag(self, tag, attrs):
-        for attr in attrs:
-            if ((attr[0]=='href' and "/annotations/" in attr[1])
-                or (attr[0]=='href' and "/diversity/" in attr[1])
-                or (attr[0]=='href' and "/expression/" in attr[1])
-                or (attr[0]=='href' and "/genetic/" in attr[1])
-                or (attr[0]=='href' and "/genomes/" in attr[1])
-                or (attr[0]=='href' and "/markers/" in attr[1])):
-                self.collections.append(attr[1])
-
-# instantiate our HTML parser
-parser = CollectionsParser()
-
-# assume jekyll-legumeinfo is next door
+# assume we're running in jekyll-legumeinfo/_scripts directory
 taxonListFile = "../_data/taxon_list.yml"
 
 # load taxon list
 f = open(taxonListFile, 'r')
 taxonList = yaml.load(f.read(), Loader=yaml.FullLoader)
 
+print("##########")
 for taxon in taxonList:
-    genusDescriptionUrl = DATASTORE_URL+"/"+taxon["genus"]+"/GENUS/about_this_collection/description_"+taxon["genus"]+".yml"
-    genusDescriptionResponse = requests.get(genusDescriptionUrl)
-    if genusDescriptionResponse.status_code==200:
-        genusDescription = yaml.load(genusDescriptionResponse.text, Loader=yaml.FullLoader)
-        speciesCollectionsFilename = "../_data/taxa/"+taxon["genus"]+"/species_collections.yml"
-        speciesCollectionsFile = open(speciesCollectionsFilename, 'w')
-        print('---', file=speciesCollectionsFile)
-        print('species:', file=speciesCollectionsFile)
-        for species in genusDescription["species"]:
-            print("### "+taxon["genus"]+" "+species)
-            print('- '+'name: '+species, file=speciesCollectionsFile)
-            speciesUrl = DATASTORE_URL+"/"+taxon["genus"]+"/"+species
-            for collectionType in ["annotations", "diversity", "expression", "genetic", "genomes", "markers"]:
+    genusDescriptionFile = "datastore-metadata/"+taxon["genus"]+"/GENUS/about_this_collection/description_"+taxon["genus"]+".yml"
+    gdf = open(genusDescriptionFile, 'r')
+    genusDescription = yaml.load(gdf.read(), Loader=yaml.FullLoader)
+    speciesCollectionsFilename = "../_data/taxa/"+taxon["genus"]+"/species_collections.yml"
+    speciesCollectionsFile = open(speciesCollectionsFilename, 'w')
+    print('---', file=speciesCollectionsFile)
+    print('species:', file=speciesCollectionsFile)
+    for species in genusDescription["species"]:
+        print("## "+taxon["genus"]+" "+species)
+        print('- '+'name: '+species, file=speciesCollectionsFile)
+        speciesDir = "datastore-metadata/"+taxon["genus"]+"/"+species
+        for collectionType in ["annotations", "diversity", "expression", "genetic", "genomes", "markers", "maps"]:
+            collectionsDir = speciesDir+"/"+collectionType+"/"
+            if os.path.isdir(collectionsDir):
                 print('  '+collectionType+':', file=speciesCollectionsFile)
-                collectionsUrl = speciesUrl+"/"+collectionType+"/"
-                collectionsResponse = requests.get(collectionsUrl)
-                if collectionsResponse.status_code==200:
-                    parser.collections = []
-                    parser.feed(collectionsResponse.text)
-                    for collectionDir in parser.collections:
-                        # /Arachis/hypogaea/annotations/Tifrunner.gnm1.ann1.CCJH/
-                        parts = collectionDir.split('/')
-                        name = parts[4]
-                        # README.Tifrunner.gnm1.ann1.CCJH.yml
-                        readmeUrl = DATASTORE_URL+collectionDir+"README."+name+".yml"
-                        readmeResponse = requests.get(readmeUrl)
-                        if readmeResponse.status_code==200:
-                            readme = yaml.load(readmeResponse.text, Loader=yaml.FullLoader)
-                            synopsis = readme["synopsis"]
-                            print('    - collection: '+name, file=speciesCollectionsFile)
-                            print('      synopsis: "'+synopsis+'"', file=speciesCollectionsFile)
-
-
-
-
+                for collection in os.listdir(collectionsDir):
+                    readmeFile = collectionsDir+collection+"/"+"README."+collection+".yml"
+                    rf = open(readmeFile, 'r')
+                    readme = yaml.load(rf.read(), Loader=yaml.FullLoader)
+                    synopsis = readme["synopsis"]
+                    print('    - collection: '+collection, file=speciesCollectionsFile)
+                    print('      synopsis: "'+synopsis+'"', file=speciesCollectionsFile)

--- a/_scripts/genus_species_resources.py
+++ b/_scripts/genus_species_resources.py
@@ -1,15 +1,16 @@
 import yaml
-import requests
+import os
 
-DATASTORE_URL = "https://data.legumeinfo.org"
+## This script assumes that datastore-metadata has been cloned in the current directory.
 
-# assume jekyll-legumeinfo is next door
+# assume we're running in jekyll-legumeinfo/_scripts directory
 taxonListFile = "../_data/taxon_list.yml"
 
 # load taxon list
 f = open(taxonListFile, 'r')
 taxonList = yaml.load(f.read(), Loader=yaml.FullLoader)
 
+## genus loop
 for taxon in taxonList:
     print("##########")
     print("## "+taxon["description"])
@@ -22,21 +23,19 @@ for taxon in taxonList:
     genusResourcesFile = open(genusResourcesFilename, 'w')
     speciesResourcesFile = open(speciesResourcesFilename, 'w')
 
-    genusDescriptionUrl = DATASTORE_URL+"/"+taxon["genus"]+"/GENUS/about_this_collection/description_"+taxon["genus"]+".yml"
-    genusDescriptionResponse = requests.get(genusDescriptionUrl)
-    if genusDescriptionResponse.status_code==200:
-        genusDescription = yaml.load(genusDescriptionResponse.text, Loader=yaml.FullLoader)
-        print("---", file=genusResourcesFile)
-        yaml.dump(genusDescription, genusResourcesFile)
-        ## species loop
-        print("---", file=speciesResourcesFile)
-        print("species:", file=speciesResourcesFile)
-        speciesDescriptions = []
-        for species in genusDescription["species"]:
-            speciesDescriptionUrl = DATASTORE_URL+"/"+taxon["genus"]+"/"+species+"/about_this_collection/description_"+taxon["genus"]+"_"+species+".yml"
-            speciesDescriptionResponse = requests.get(speciesDescriptionUrl)
-            if speciesDescriptionResponse.status_code==200:
-                speciesDescription = yaml.load(speciesDescriptionResponse.text, Loader=yaml.FullLoader)
-                speciesDescriptions.append(speciesDescription)
-        ## dump out species_resources.yml
-        yaml.dump(speciesDescriptions, speciesResourcesFile)
+    genusDescriptionFile = "datastore-metadata/"+taxon["genus"]+"/GENUS/about_this_collection/description_"+taxon["genus"]+".yml"
+    gdf = open(genusDescriptionFile, 'r')
+    genusDescription = yaml.load(gdf.read(), Loader=yaml.FullLoader)
+    print("---", file=genusResourcesFile)
+    yaml.dump(genusDescription, genusResourcesFile)
+    ## species loop
+    print("---", file=speciesResourcesFile)
+    print("species:", file=speciesResourcesFile)
+    speciesDescriptions = []
+    for species in genusDescription["species"]:
+        speciesDescriptionFile = "datastore-metadata/"+taxon["genus"]+"/"+species+"/about_this_collection/description_"+taxon["genus"]+"_"+species+".yml"
+        sdf = open(speciesDescriptionFile, 'r')
+        speciesDescription = yaml.load(sdf.read(), Loader=yaml.FullLoader)
+        speciesDescriptions.append(speciesDescription)
+    ## dump out species_resources.yml
+    yaml.dump(speciesDescriptions, speciesResourcesFile)


### PR DESCRIPTION
This is the update we talked about yesterday, @nathanweeks and @adf-ncgr . Stuff that's just hanging in the DS that isn't yet validated or added to the repo can be suspect, so this is an improvement.

The _scripts/build-data-yaml runner could be added to the GA for merges to main so that the staging site has the latest-greatest after a merge. Note that the scripts require Python 3.9+ because of newer features of pyyaml that are used. That's why the build-data-yaml runner explicitly invokes python3.9. I don't think there's any big rush to implement such a GA.